### PR TITLE
Proposed fix

### DIFF
--- a/simple-jwt-login/routes/api.php
+++ b/simple-jwt-login/routes/api.php
@@ -106,9 +106,16 @@ add_action('rest_api_init', function () {
                 ->withServerHelper($serverHelper)
                 ->withRouteService($routeService);
 
-            $currentURl = $_SERVER['REQUEST_URI'];
+            $currentURL =
+                "http"
+                . (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? "s" : "")
+                . "://" . $_SERVER['HTTP_HOST']
+                . $_SERVER['REQUEST_URI'];
+            $currentURL = str_replace( home_url(), "",$currentURL);
+
             $documentRoot = $_SERVER['DOCUMENT_ROOT'];
-            $hasAccess = $service->hasAccess($currentURl, $documentRoot, $request) ;
+
+            $hasAccess = $service->hasAccess($currentURL, $documentRoot, $request) ;
             if ($hasAccess=== false ) {
                 @header('Content-Type: application/json; charset=UTF-8');
                 wp_send_json_error(

--- a/simple-jwt-login/src/Services/ProtectEndpointService.php
+++ b/simple-jwt-login/src/Services/ProtectEndpointService.php
@@ -124,6 +124,7 @@ class ProtectEndpointService extends BaseService
         $isEndpointProtected = $defaultValue;
         foreach ($domains as $protectedEndpoint) {
             $protectedEndpoint = $this->removeWpJsonFromEndpoint($protectedEndpoint);
+            $endpoint = $this->removeWpJsonFromEndpoint($endpoint);
             if (empty(trim($protectedEndpoint, '/'))) {
                 continue;
             }


### PR DESCRIPTION
## Issue Link
Protect Endpoints bug with Whitelisted and Protected endpoints https://github.com/nicumicle/simple-jwt-login/issues/14

## Types of changes
- [x] Bug fix
- [ ] New feature

## Description
Allows you to protect endpoints even if your wordpress installation is in a subfolder of your domain.

There are three modifications.

**api.php**

1. The `$currentURL` is calculated as in _isMiddlewareEnabled()_. It is a complete url, from domain up.
2. The `$currentURL` is stripped from `home_url()` making all setup have an even result: ex.

   - https://mydomain.xxx/wordpress/wp-json is taken in account and becomes _/wp-json_ 
   - https://mydomain.xxx/wp-json works as before and becomes  _/wp-json_

**ProtectEndpointService.php**

1. wp-json is removed from `$endpoint` and allows a correct comparison with `$protectedEndpoint`: if wp-json is not present, it works as before.


## How has this been tested?

This changes pass all unchanged tests.
This changes affects only the ProtectedEndpoint feature.

## Checklist:
- [ x ] My code is tested.
- [ ] I wrote tests for the impacted area
- [ x ] My code follows Simple-JWT-login code style