### PR TITLE
Proposed: ProtectEndpointService.php sets the current user in wp. Ref #16.

### DIFF
--- a/simple-jwt-login/src/Modules/WordPressData.php
+++ b/simple-jwt-login/src/Modules/WordPressData.php
@@ -284,6 +284,16 @@ class WordPressData implements WordPressDataInterface
     }
 
     /**
+     * @param int $userId
+     * @return bool|WP_User
+     */
+    public function currentUser($userId)
+    {
+        return wp_set_current_user($userId);
+    }
+
+
+    /**
      * @param string|null $password
      * @param string|null $passwordHash
      * @param string $dbPassword

--- a/simple-jwt-login/src/Modules/WordPressDataInterface.php
+++ b/simple-jwt-login/src/Modules/WordPressDataInterface.php
@@ -161,6 +161,12 @@ interface WordPressDataInterface
     public function addUserMeta($userId, $metaKey, $value);
 
     /**
+     * @param int $userId
+     * @return bool|WP_User
+     */
+    public function currentUser($userId);
+
+    /**
      * @param WP_User$user
      *
      * @return mixed

--- a/simple-jwt-login/src/Services/ProtectEndpointService.php
+++ b/simple-jwt-login/src/Services/ProtectEndpointService.php
@@ -53,6 +53,7 @@ class ProtectEndpointService extends BaseService
         try {
             $jwt = $this->getJwtFromRequestHeaderOrCookie();
             $userID = $this->routeService->getUserIdFromJWT($jwt);
+            $this->wordPressData->currentUser($userID);
 
             return !empty($userID);
         } catch (\Exception $e) {

--- a/tests/Services/ProtectEndpointServiceTest.php
+++ b/tests/Services/ProtectEndpointServiceTest.php
@@ -8,6 +8,7 @@ use SimpleJWTLogin\Libraries\JWT;
 use SimpleJWTLogin\Modules\Settings\ProtectEndpointSettings;
 use SimpleJWTLogin\Modules\SimpleJWTLoginSettings;
 use SimpleJWTLogin\Modules\WordPressData;
+use SimpleJWTLogin\Modules\WordPressDataInterface;
 use SimpleJWTLogin\Services\ProtectEndpointService;
 use SimpleJWTLogin\Services\RouteService;
 
@@ -28,6 +29,8 @@ class ProtectEndpointServiceTest extends TestCase
             ->willReturn('http://test.com');
         $this->wordPressData->method('getAdminUrl')
             ->willReturn('http://test.com/wp-admin/');
+        $this->wordPressData->method('currentUser')
+            ->willReturn(true);
     }
 
     /**

--- a/tests/Services/ProtectEndpointServiceTest.php
+++ b/tests/Services/ProtectEndpointServiceTest.php
@@ -8,7 +8,6 @@ use SimpleJWTLogin\Libraries\JWT;
 use SimpleJWTLogin\Modules\Settings\ProtectEndpointSettings;
 use SimpleJWTLogin\Modules\SimpleJWTLoginSettings;
 use SimpleJWTLogin\Modules\WordPressData;
-use SimpleJWTLogin\Modules\WordPressDataInterface;
 use SimpleJWTLogin\Services\ProtectEndpointService;
 use SimpleJWTLogin\Services\RouteService;
 


### PR DESCRIPTION
## Issue Link
Ability to:

get current user in custom registered endpoints
( ex. `wp_get_current_user()` returns the correct data)

and

correctly use the _permission_callback_ in register_rest_route 
(ex.
```
   'permission_callback' => function ($request ) {
      if (current_user_can('edit_others_posts'))
         return true;
```
)
Ref. #16 


## Types of changes
- [ ] Bug fix
- [x] New feature

## Description
Changes are:
1
add the
`wp_set_current_user($userId)`
function in _Modules/WordPressData.php_ and _Modules/WordPressDataInterface.php_ (called _currentUser_)
2
use the declared _currentUser_ function in _ProtectEndpointService.php_ to set the current user and get the ability to perform actions as other users.
3
Add the method in ProtectEndpointServiceTest.
It does not really perform any test

## How has this been tested?
It does passes the tests but, please note, it **does not check the validity of the WP_User returned** (that is why I don't flag the checklist).

## Checklist:
- [ ] My code is tested.
- [ ] I wrote tests for the impacted area
- [x] My code follows Simple-JWT-login code style