### PR TITLE
fix checking jwt header

### DIFF
--- a/simple-jwt-login/src/Services/BaseService.php
+++ b/simple-jwt-login/src/Services/BaseService.php
@@ -162,7 +162,7 @@ abstract class BaseService
         if ($this->jwtSettings->getGeneralSettings()->isJwtFromHeaderEnabled()) {
             $headers = array_change_key_case($this->serverHelper->getHeaders(), CASE_LOWER);
             $headerKey = strtolower($this->jwtSettings->getGeneralSettings()->getRequestKeyHeader());
-            if (isset($headers[$headerKey]) && !empty(trim($headers[$headerKey]))) {
+            if (isset($headers[$headerKey])) {
                 $matches = [];
                 preg_match(
                     '/^(?:Bearer)?[\s]*(.*)$/mi',
@@ -170,7 +170,7 @@ abstract class BaseService
                     $matches
                 );
 
-                if (isset($matches[1])) {
+                if (isset($matches[1]) && !empty(trim($matches[1]))) {
                     return $matches[1];
                 }
             }


### PR DESCRIPTION
## Types of changes
- [x] Bug fix

## Description
Fix checking jwt when header option is enable.
If we enable header option alongside other options like url the an empty header will cause a `23 error code` (wrong request).
But if we check that header is empty or not we can skip it when it is empty.
An empty header doesn't require matching `Bearer {token}`.

## Checklist:
- [x] My code is tested.
- [x] My code follows Simple-JWT-login code style