### PR TITLE
BugFix: user_meta is ignored when passed as json in request body

### DIFF
--- a/simple-jwt-login/src/Services/RegisterUserService.php
+++ b/simple-jwt-login/src/Services/RegisterUserService.php
@@ -76,7 +76,7 @@ class RegisterUserService extends BaseService implements ServiceInterface
 
         if (!empty($this->request['user_meta'])) {
             $userMeta = $this->request['user_meta'];
-            if(is_string($userMeta)) {
+            if (is_string($userMeta)) {
                 $userMeta = json_decode($this->request['user_meta'], true);
                 if ($userMeta === null
                     && strpos($this->request['user_meta'], '\\"') !== false

--- a/simple-jwt-login/src/Services/RegisterUserService.php
+++ b/simple-jwt-login/src/Services/RegisterUserService.php
@@ -75,14 +75,17 @@ class RegisterUserService extends BaseService implements ServiceInterface
         $userId = $this->wordPressData->getUserIdFromUser($user);
 
         if (!empty($this->request['user_meta'])) {
-            $userMeta = json_decode($this->request['user_meta'], true);
-            if ($userMeta === null
-                && strpos($this->request['user_meta'], '\\"') !== false
-            ) {
-                $userMeta = json_decode(
-                    stripslashes($this->request['user_meta']),
-                    true
-                );
+            $userMeta = $this->request['user_meta'];
+            if(is_string($userMeta)) {
+                $userMeta = json_decode($this->request['user_meta'], true);
+                if ($userMeta === null
+                    && strpos($this->request['user_meta'], '\\"') !== false
+                ) {
+                    $userMeta = json_decode(
+                        stripslashes($this->request['user_meta']),
+                        true
+                    );
+                }
             }
             $allowedUserMetaKeys = array_map(function ($value) {
                 return trim($value);


### PR DESCRIPTION
Fixes #28


## Issue Link
https://github.com/nicumicle/simple-jwt-login/issues/28

## Types of changes
- [x] Bug fix
- [ ] New feature

## Description
The code change will apply json decode the user_meta content only if it's a string

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Checklist:
- [ ] My code is tested.
- [ ] I wrote tests for the impacted area
- [ ] My code follows Simple-JWT-login code style