### PR TITLE
feat(authenticate-service): add filter to modify payload

### DIFF
--- a/simple-jwt-login/src/Services/AuthenticateService.php
+++ b/simple-jwt-login/src/Services/AuthenticateService.php
@@ -57,6 +57,9 @@ class AuthenticateService extends BaseService implements ServiceInterface
                     break;
             }
         }
+        
+        // Allow developers to create their own payload values inside of the returned JWT
+        $payload = apply_filters('simple_jwt_login_generate_payload', $payload, $wordPressData, $user);
 
         return $payload;
     }


### PR DESCRIPTION
## Issue Link
[https://github.com/nicumicle/simple-jwt-login/issues/47](https://github.com/nicumicle/simple-jwt-login/issues/47)

## Types of changes
- [X] New feature

## Description
I needed to extend the returned payload from the plugin. The plugin only allows you to choose from a fixed number of payload options. By adding in a filter called `simple_jwt_login_generate_payload`, we can add new payload values to the generated JSON Web Token. I needed this to add a user avatar to the payload.

## How has this been tested?
This is a minor addition and has been tested in a real-world application. An example of this filter being used can be found in this open source application [here](https://github.com/Vheissu/huntr/blob/main/wp-content/themes/application-theme/functions.php#L71-L80).

As the `apply_filters` API is being used to pass in the `$payload` variable and then return it, nothing happens by default unless the user implements their own filter hook.

Please note that I did not write any test cases for this, as the behaviour introduced into this change is related to a WordPress API function.

## Checklist:
- [X] My code is tested.
- [X] My code follows Simple-JWT-login code style