### PR TITLE
Iss

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,7 @@
 # Changelog - Releases
 
 ## Unreleased
-
+- Add `iss` to JWT payload and allow to configure it
 
 ## 3.5.1 (1 October 2023)
 - Update WordPress 6.3 compatibility

--- a/simple-jwt-login/src/ErrorCodes.php
+++ b/simple-jwt-login/src/ErrorCodes.php
@@ -72,4 +72,6 @@ class ErrorCodes
     const ERR_RESET_PASSWORD_INVALID_FLOW = 65;
     const ERR_MISSING_CODE_FROM_EMAIL_BODY = 66;
     const ERR_INVALID_NONCE = 67;
+
+    const ERR_INVALID_IIS_LOGIN = 68;
 }

--- a/simple-jwt-login/src/Helpers/ArrayHelper.php
+++ b/simple-jwt-login/src/Helpers/ArrayHelper.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace SimpleJWTLogin\Helpers;
+
+class ArrayHelper
+{
+    /**
+     * @param string $string
+     * @return array|string[]
+     */
+    public static function convertStringToArray($string)
+    {
+        return array_map(function ($value) {
+            return trim($value);
+        }, explode(',', $string));
+    }
+}

--- a/simple-jwt-login/src/Modules/Settings/AuthenticationSettings.php
+++ b/simple-jwt-login/src/Modules/Settings/AuthenticationSettings.php
@@ -12,7 +12,7 @@ class AuthenticationSettings extends BaseSettings implements SettingsInterface
     const JWT_PAYLOAD_PARAM_ID = 'id';
     const JWT_PAYLOAD_PARAM_SITE = 'site';
     const JWT_PAYLOAD_PARAM_USERNAME = 'username';
-    const JWT_IIS = 'iis';
+    const JWT_ISS = 'iss';
 
     public function initSettingsFromPost()
     {
@@ -68,9 +68,9 @@ class AuthenticationSettings extends BaseSettings implements SettingsInterface
         );
         $this->assignSettingsPropertyFromPost(
             null,
-            'jwt_auth_iis',
+            'jwt_auth_iss',
             null,
-            'jwt_auth_iis',
+            'jwt_auth_iss',
             BaseSettings::SETTINGS_TYPE_STRING
         );
     }
@@ -162,7 +162,7 @@ class AuthenticationSettings extends BaseSettings implements SettingsInterface
             self::JWT_PAYLOAD_PARAM_ID,
             self::JWT_PAYLOAD_PARAM_SITE,
             self::JWT_PAYLOAD_PARAM_USERNAME,
-            self::JWT_IIS,
+            self::JWT_ISS,
         ];
     }
 
@@ -189,10 +189,10 @@ class AuthenticationSettings extends BaseSettings implements SettingsInterface
     /**
      * @return string
      */
-    public function getAuthIis()
+    public function getAuthIss()
     {
-        return isset($this->settings['jwt_auth_iis'])
-            ? (string)$this->settings['jwt_auth_iis']
+        return isset($this->settings['jwt_auth_iss'])
+            ? (string)$this->settings['jwt_auth_iss']
             : $this->wordPressData->getSiteUrl();
     }
 

--- a/simple-jwt-login/src/Modules/Settings/AuthenticationSettings.php
+++ b/simple-jwt-login/src/Modules/Settings/AuthenticationSettings.php
@@ -12,7 +12,7 @@ class AuthenticationSettings extends BaseSettings implements SettingsInterface
     const JWT_PAYLOAD_PARAM_ID = 'id';
     const JWT_PAYLOAD_PARAM_SITE = 'site';
     const JWT_PAYLOAD_PARAM_USERNAME = 'username';
-    const JWT_ISS = 'iss';
+    const JWT_PAYLOAD_PARAM_ISS = 'iss';
 
     public function initSettingsFromPost()
     {
@@ -162,7 +162,7 @@ class AuthenticationSettings extends BaseSettings implements SettingsInterface
             self::JWT_PAYLOAD_PARAM_ID,
             self::JWT_PAYLOAD_PARAM_SITE,
             self::JWT_PAYLOAD_PARAM_USERNAME,
-            self::JWT_ISS,
+            self::JWT_PAYLOAD_PARAM_ISS,
         ];
     }
 

--- a/simple-jwt-login/src/Modules/Settings/AuthenticationSettings.php
+++ b/simple-jwt-login/src/Modules/Settings/AuthenticationSettings.php
@@ -12,6 +12,7 @@ class AuthenticationSettings extends BaseSettings implements SettingsInterface
     const JWT_PAYLOAD_PARAM_ID = 'id';
     const JWT_PAYLOAD_PARAM_SITE = 'site';
     const JWT_PAYLOAD_PARAM_USERNAME = 'username';
+    const JWT_IIS = 'iis';
 
     public function initSettingsFromPost()
     {
@@ -64,6 +65,13 @@ class AuthenticationSettings extends BaseSettings implements SettingsInterface
             'auth_password_base64',
             BaseSettings::SETTINGS_TYPE_BOL,
             false
+        );
+        $this->assignSettingsPropertyFromPost(
+            null,
+            'jwt_auth_iis',
+            null,
+            'jwt_auth_iis',
+            BaseSettings::SETTINGS_TYPE_STRING
         );
     }
 
@@ -153,7 +161,8 @@ class AuthenticationSettings extends BaseSettings implements SettingsInterface
             self::JWT_PAYLOAD_PARAM_EMAIL,
             self::JWT_PAYLOAD_PARAM_ID,
             self::JWT_PAYLOAD_PARAM_SITE,
-            self::JWT_PAYLOAD_PARAM_USERNAME
+            self::JWT_PAYLOAD_PARAM_USERNAME,
+            self::JWT_IIS,
         ];
     }
 
@@ -175,6 +184,16 @@ class AuthenticationSettings extends BaseSettings implements SettingsInterface
         return isset($this->settings['jwt_auth_refresh_ttl'])
             ? (int)$this->settings['jwt_auth_refresh_ttl']
             : 20160;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAuthIis()
+    {
+        return isset($this->settings['jwt_auth_iis'])
+            ? (string)$this->settings['jwt_auth_iis']
+            : $this->wordPressData->getSiteUrl();
     }
 
     /**

--- a/simple-jwt-login/src/Modules/Settings/LoginSettings.php
+++ b/simple-jwt-login/src/Modules/Settings/LoginSettings.php
@@ -94,6 +94,13 @@ class LoginSettings extends BaseSettings implements SettingsInterface
             'login_ip',
             BaseSettings::SETTINGS_TYPE_STRING
         );
+        $this->assignSettingsPropertyFromPost(
+            null,
+            'login_iss',
+            null,
+            'login_iss',
+            BaseSettings::SETTINGS_TYPE_STRING
+        );
     }
 
     public function validateSettings()
@@ -202,6 +209,16 @@ class LoginSettings extends BaseSettings implements SettingsInterface
     {
         return isset($this->settings['login_ip'])
             ? $this->settings['login_ip']
+            : '';
+    }
+
+    /**
+     * @return string
+     */
+    public function getAllowedLoginIss()
+    {
+        return isset($this->settings['login_iss'])
+            ? $this->settings['login_iss']
             : '';
     }
 

--- a/simple-jwt-login/src/Modules/SimpleJWTLoginSettings.php
+++ b/simple-jwt-login/src/Modules/SimpleJWTLoginSettings.php
@@ -88,6 +88,7 @@ class SimpleJWTLoginSettings
             return self::$settingsInstances[$type];
         }
         self::$settingsInstances[$type] = SettingsFactory::getFactory($type)
+            ->withWordPressData($this->getWordPressData())
             ->withSettings($this->settings);
 
         return self::$settingsInstances[$type];

--- a/simple-jwt-login/src/Services/AuthenticateService.php
+++ b/simple-jwt-login/src/Services/AuthenticateService.php
@@ -55,6 +55,9 @@ class AuthenticateService extends BaseService implements ServiceInterface
                 case AuthenticationSettings::JWT_PAYLOAD_PARAM_USERNAME:
                     $payload[$parameter] = $wordPressData->getUserProperty($user, 'user_login');
                     break;
+                case AuthenticationSettings::JWT_IIS:
+                    $payload[$parameter] = $jwtSettings->getAuthenticationSettings()->getAuthIis();
+                    break;
             }
         }
         

--- a/simple-jwt-login/src/Services/AuthenticateService.php
+++ b/simple-jwt-login/src/Services/AuthenticateService.php
@@ -55,7 +55,7 @@ class AuthenticateService extends BaseService implements ServiceInterface
                 case AuthenticationSettings::JWT_PAYLOAD_PARAM_USERNAME:
                     $payload[$parameter] = $wordPressData->getUserProperty($user, 'user_login');
                     break;
-                case AuthenticationSettings::JWT_ISS:
+                case AuthenticationSettings::JWT_PAYLOAD_PARAM_ISS:
                     $payload[$parameter] = $jwtSettings->getAuthenticationSettings()->getAuthIss();
                     break;
             }

--- a/simple-jwt-login/src/Services/AuthenticateService.php
+++ b/simple-jwt-login/src/Services/AuthenticateService.php
@@ -55,8 +55,8 @@ class AuthenticateService extends BaseService implements ServiceInterface
                 case AuthenticationSettings::JWT_PAYLOAD_PARAM_USERNAME:
                     $payload[$parameter] = $wordPressData->getUserProperty($user, 'user_login');
                     break;
-                case AuthenticationSettings::JWT_IIS:
-                    $payload[$parameter] = $jwtSettings->getAuthenticationSettings()->getAuthIis();
+                case AuthenticationSettings::JWT_ISS:
+                    $payload[$parameter] = $jwtSettings->getAuthenticationSettings()->getAuthIss();
                     break;
             }
         }

--- a/simple-jwt-login/src/Services/LoginService.php
+++ b/simple-jwt-login/src/Services/LoginService.php
@@ -128,7 +128,7 @@ class LoginService extends BaseService implements ServiceInterface
                 !in_array($payload['iss'], ArrayHelper::convertStringToArray($allowedIss))) {
                 throw new Exception(
                     __('The JWT issuer(iss) is not allowed to auto-login.', 'simple-jwt-login'),
-                    ErrorCodes::ERR_IP_IS_NOT_ALLOWED_TO_LOGIN
+                    ErrorCodes::ERR_INVALID_IIS_LOGIN
                 );
             }
         }

--- a/simple-jwt-login/src/Services/LoginService.php
+++ b/simple-jwt-login/src/Services/LoginService.php
@@ -4,6 +4,7 @@ namespace SimpleJWTLogin\Services;
 
 use Exception;
 use SimpleJWTLogin\ErrorCodes;
+use SimpleJWTLogin\Helpers\ArrayHelper;
 use SimpleJWTLogin\Helpers\Jwt\JwtKeyFactory;
 use SimpleJWTLogin\Libraries\JWT\JWT;
 use SimpleJWTLogin\Modules\Settings\LoginSettings;
@@ -73,10 +74,12 @@ class LoginService extends BaseService implements ServiceInterface
     }
 
     /**
+     * @SuppressWarnings(StaticAccess)
      * @throws Exception
      */
     private function validateDoLogin()
     {
+        // Validate Autologin is enabled
         $this->jwt = $this->getJwtFromRequestHeaderOrCookie();
         if ($this->jwtSettings->getLoginSettings()->isAutologinEnabled() === false) {
             throw new Exception(
@@ -85,6 +88,7 @@ class LoginService extends BaseService implements ServiceInterface
             );
         }
 
+        // Check if JWT is present
         if (empty($this->jwt)) {
             throw new Exception(
                 __('Wrong Request.', 'simple-jwt-login'),
@@ -92,6 +96,7 @@ class LoginService extends BaseService implements ServiceInterface
             );
         }
 
+        // Validate AUTH KEY
         if ($this->jwtSettings->getLoginSettings()->isAuthKeyRequiredOnLogin() && $this->validateAuthKey() === false) {
             throw  new Exception(
                 sprintf(
@@ -101,6 +106,8 @@ class LoginService extends BaseService implements ServiceInterface
                 ErrorCodes::ERR_INVALID_AUTH_CODE_PROVIDED
             );
         }
+
+        // Validate IP
         $allowedIPs = $this->jwtSettings->getLoginSettings()->getAllowedLoginIps();
         if (!empty($allowedIPs) && !$this->serverHelper->isClientIpInList($allowedIPs)) {
             throw new Exception(
@@ -110,6 +117,20 @@ class LoginService extends BaseService implements ServiceInterface
                 ),
                 ErrorCodes::ERR_IP_IS_NOT_ALLOWED_TO_LOGIN
             );
+        }
+
+        // Validate ISS
+        $allowedIss = $this->jwtSettings->getLoginSettings()->getAllowedLoginIss();
+        if (!empty($allowedIss)) {
+            $payload = $this->getPayloadFromJWT($this->jwt);
+            if ($payload == null  ||
+                !isset($payload['iss']) ||
+                !in_array($payload['iss'], ArrayHelper::convertStringToArray($allowedIss))) {
+                throw new Exception(
+                    __('The JWT issuer(iss) is not allowed to auto-login.', 'simple-jwt-login'),
+                    ErrorCodes::ERR_IP_IS_NOT_ALLOWED_TO_LOGIN
+                );
+            }
         }
     }
 }

--- a/simple-jwt-login/src/Services/RegisterUserService.php
+++ b/simple-jwt-login/src/Services/RegisterUserService.php
@@ -280,15 +280,15 @@ class RegisterUserService extends BaseService implements ServiceInterface
             ->getUserProperty($user, 'ID');
         $username = $this->wordPressData
             ->getUserProperty($user, 'user_login');
-        $iis = $this->jwtSettings
-            ->getAuthenticationSettings()->getAuthIis();
+        $iss = $this->jwtSettings
+            ->getAuthenticationSettings()->getAuthIss();
 
         return [
             AuthenticationSettings::JWT_PAYLOAD_PARAM_EMAIL    => $userEmail,
             AuthenticationSettings::JWT_PAYLOAD_PARAM_ID       => $userId,
             AuthenticationSettings::JWT_PAYLOAD_PARAM_USERNAME => $username,
             AuthenticationSettings::JWT_PAYLOAD_PARAM_IAT      => time(),
-            AuthenticationSettings::JWT_IIS                    => $iis,
+            AuthenticationSettings::JWT_ISS                    => $iss,
         ];
     }
 }

--- a/simple-jwt-login/src/Services/RegisterUserService.php
+++ b/simple-jwt-login/src/Services/RegisterUserService.php
@@ -288,7 +288,7 @@ class RegisterUserService extends BaseService implements ServiceInterface
             AuthenticationSettings::JWT_PAYLOAD_PARAM_ID       => $userId,
             AuthenticationSettings::JWT_PAYLOAD_PARAM_USERNAME => $username,
             AuthenticationSettings::JWT_PAYLOAD_PARAM_IAT      => time(),
-            AuthenticationSettings::JWT_ISS                    => $iss,
+            AuthenticationSettings::JWT_PAYLOAD_PARAM_ISS                    => $iss,
         ];
     }
 }

--- a/simple-jwt-login/src/Services/RegisterUserService.php
+++ b/simple-jwt-login/src/Services/RegisterUserService.php
@@ -280,12 +280,15 @@ class RegisterUserService extends BaseService implements ServiceInterface
             ->getUserProperty($user, 'ID');
         $username = $this->wordPressData
             ->getUserProperty($user, 'user_login');
+        $iis = $this->jwtSettings
+            ->getAuthenticationSettings()->getAuthIis();
 
         return [
             AuthenticationSettings::JWT_PAYLOAD_PARAM_EMAIL    => $userEmail,
             AuthenticationSettings::JWT_PAYLOAD_PARAM_ID       => $userId,
             AuthenticationSettings::JWT_PAYLOAD_PARAM_USERNAME => $username,
             AuthenticationSettings::JWT_PAYLOAD_PARAM_IAT      => time(),
+            AuthenticationSettings::JWT_IIS                    => $iis,
         ];
     }
 }

--- a/simple-jwt-login/views/auth-view.php
+++ b/simple-jwt-login/views/auth-view.php
@@ -191,6 +191,7 @@ if (! defined('ABSPATH')) {
                     <ul>
 						<?php
                         $payloadParameters = $jwtSettings->getAuthenticationSettings()->getJwtPayloadParameters();
+                        sort($payloadParameters, SORT_ASC);
                         foreach ($payloadParameters as $parameterIndex => $parameter
                         ) {
                             $numberOfLines = count($payloadParameters) - 1;
@@ -215,6 +216,9 @@ if (! defined('ABSPATH')) {
                                     break;
                                 case AuthenticationSettings::JWT_PAYLOAD_PARAM_USERNAME:
                                     $sampleValue = 'WordPresUser_login';
+                                    break;
+                                case AuthenticationSettings::JWT_IIS:
+                                    $sampleValue = $jwtSettings->getAuthenticationSettings()->getAuthIis();
                                     break;
                                 default:
                                     $sampleValue = '';
@@ -297,7 +301,7 @@ if (! defined('ABSPATH')) {
             ?>
 			<?php echo __('JWT time to live', 'simple-jwt-login') ?>
         </h3>
-        <label>
+        <label for="jwt_auth_ttl">
 			<?php echo __(
                 'Specify the length of time (in minutes) that the token will be valid for.',
                 'simple-jwt-login'
@@ -328,7 +332,7 @@ if (! defined('ABSPATH')) {
             ?>
 			<?php echo __('Refresh time to live', 'simple-jwt-login') ?>
         </h3>
-        <label for="jwt_login_by_paramter">
+        <label for="jwt_auth_refresh_ttl">
 			<?php echo __(
                 'Specify the length of time (in minutes) that the token can be refreshed within.'
                 . ' I.E. The user can refresh their token within a 2 week window of the original token'
@@ -343,6 +347,29 @@ if (! defined('ABSPATH')) {
                 id="jwt_auth_refresh_ttl"
                 value="<?php echo esc_attr($jwtSettings->getAuthenticationSettings()->getAuthJwtRefreshTtl()); ?>"
                 placeholder="<?php echo __('Number of minutes', 'simple-jwt-login') ?>"
+        />
+    </div>
+</div>
+<hr/>
+
+<div class="row">
+    <div class="col-md-12">
+        <h3 class="section-title">
+            <?php echo __('JWT Issuer (iis)', 'simple-jwt-login') ?>
+        </h3>
+        <label for="jwt_auth_ttl">
+            <?php echo __(
+                'The iss when a new JWT is generated',
+                'simple-jwt-login'
+            ); ?>
+        </label>
+        <input
+            type="text"
+            name="jwt_auth_iis"
+            class="form-control"
+            id="jwt_auth_iis"
+            value="<?php echo esc_attr($jwtSettings->getAuthenticationSettings()->getAuthIis()); ?>"
+            placeholder="<?php echo __('Default iis', 'simple-jwt-login') ?>"
         />
     </div>
 </div>

--- a/simple-jwt-login/views/auth-view.php
+++ b/simple-jwt-login/views/auth-view.php
@@ -217,8 +217,8 @@ if (! defined('ABSPATH')) {
                                 case AuthenticationSettings::JWT_PAYLOAD_PARAM_USERNAME:
                                     $sampleValue = 'WordPresUser_login';
                                     break;
-                                case AuthenticationSettings::JWT_IIS:
-                                    $sampleValue = $jwtSettings->getAuthenticationSettings()->getAuthIis();
+                                case AuthenticationSettings::JWT_ISS:
+                                    $sampleValue = $jwtSettings->getAuthenticationSettings()->getAuthIss();
                                     break;
                                 default:
                                     $sampleValue = '';
@@ -355,21 +355,21 @@ if (! defined('ABSPATH')) {
 <div class="row">
     <div class="col-md-12">
         <h3 class="section-title">
-            <?php echo __('JWT Issuer (iis)', 'simple-jwt-login') ?>
+            <?php echo __('JWT Issuer (iss)', 'simple-jwt-login') ?>
         </h3>
         <label for="jwt_auth_ttl">
             <?php echo __(
-                'The iss when a new JWT is generated',
+                'The payload issuer when a new JWT is generated',
                 'simple-jwt-login'
             ); ?>
         </label>
         <input
             type="text"
-            name="jwt_auth_iis"
+            name="jwt_auth_iss"
             class="form-control"
-            id="jwt_auth_iis"
-            value="<?php echo esc_attr($jwtSettings->getAuthenticationSettings()->getAuthIis()); ?>"
-            placeholder="<?php echo __('Default iis', 'simple-jwt-login') ?>"
+            id="jwt_auth_iss"
+            value="<?php echo esc_attr($jwtSettings->getAuthenticationSettings()->getAuthIss()); ?>"
+            placeholder="<?php echo __('Default issuer', 'simple-jwt-login') ?>"
         />
     </div>
 </div>

--- a/simple-jwt-login/views/auth-view.php
+++ b/simple-jwt-login/views/auth-view.php
@@ -217,7 +217,7 @@ if (! defined('ABSPATH')) {
                                 case AuthenticationSettings::JWT_PAYLOAD_PARAM_USERNAME:
                                     $sampleValue = 'WordPresUser_login';
                                     break;
-                                case AuthenticationSettings::JWT_ISS:
+                                case AuthenticationSettings::JWT_PAYLOAD_PARAM_ISS:
                                     $sampleValue = $jwtSettings->getAuthenticationSettings()->getAuthIss();
                                     break;
                                 default:

--- a/simple-jwt-login/views/login-view.php
+++ b/simple-jwt-login/views/login-view.php
@@ -374,3 +374,21 @@ if (! defined('ABSPATH')) {
         </div>
     </div>
 </div>
+
+<div class="row">
+    <div class="col-md-12">
+        <h3 class="section-title">
+            <?php echo __('JWT Allowed issuers (iss) for Auto-Login', 'simple-jwt-login');?>:
+        </h3>
+        <div class="form-group">
+            <input type="text" id="login_iss" name="login_iss" class="form-control"
+                   value="<?php echo esc_attr($jwtSettings->getLoginSettings()->getAllowedLoginIss()); ?>"
+                   placeholder="<?php echo __('Enter allowed iss here', 'simple-jwt-login'); ?>"/>
+            <p class="text-muted">
+                <?php echo __("If you want to add more issuers (iss), separate them by comma", 'simple-jwt-login'); ?>.
+                <br/>
+                <?php echo __('Leave blank to allow all issuers (iss)', 'simple-jwt-login'); ?>.
+            </p>
+        </div>
+    </div>
+</div>

--- a/simple-jwt-login/views/reset-password-view.php
+++ b/simple-jwt-login/views/reset-password-view.php
@@ -145,8 +145,7 @@ if (!defined('ABSPATH')) {
         <ul>
             <li>
                 <input type="radio"
-                       value="<?php
-                       echo esc_attr(ResetPasswordSettings::FLOW_JUST_SAVE_IN_DB); ?>"
+                       value="<?php echo esc_attr(ResetPasswordSettings::FLOW_JUST_SAVE_IN_DB); ?>"
                     <?php
                     echo (
                         $jwtSettings->getResetPasswordSettings()->getFlowType()
@@ -171,14 +170,14 @@ if (!defined('ABSPATH')) {
             <li>
                 <input type="radio"
                        value="<?php
-                       echo esc_attr(ResetPasswordSettings::FLOW_SEND_DEFAULT_WP_EMAIL); ?>"
+                        echo esc_attr(ResetPasswordSettings::FLOW_SEND_DEFAULT_WP_EMAIL); ?>"
                     <?php
-                    echo($jwtSettings->getResetPasswordSettings()->getFlowType()
-                    === ResetPasswordSettings::FLOW_SEND_DEFAULT_WP_EMAIL
-                        ? 'checked="checked"'
-                        : ''
-                    );
-                    ?>
+                        echo($jwtSettings->getResetPasswordSettings()->getFlowType()
+                        === ResetPasswordSettings::FLOW_SEND_DEFAULT_WP_EMAIL
+                            ? 'checked="checked"'
+                            : ''
+                        );
+                        ?>
                        name="jwt_reset_password_flow"
                        class="jwt_reset_password_flow"
                        id="jwt_reset_password_flow_wordpress"
@@ -230,7 +229,7 @@ if (!defined('ABSPATH')) {
                    class="form-control"
                    placeholder="<?php echo __('Email Subject', 'simple-jwt-login'); ?>"
                    value="<?php
-                   echo esc_attr($jwtSettings->getResetPasswordSettings()->getResetPasswordEmailSubject()); ?>"
+                    echo esc_attr($jwtSettings->getResetPasswordSettings()->getResetPasswordEmailSubject()); ?>"
             />
             <br/>
             <h4 class="sub-section-title">Email body</h4>
@@ -239,8 +238,7 @@ if (!defined('ABSPATH')) {
                       id="reset_password_email_body"
                       placeholder="Email Content"
             ><?php
-                echo esc_html($jwtSettings->getResetPasswordSettings()->getResetPasswordEmailBody());
-                ?></textarea>
+                echo esc_html($jwtSettings->getResetPasswordSettings()->getResetPasswordEmailBody()); ?></textarea>
             <br/>
             <h4 class="sub-section-title">Email type</h4>
             <ul>
@@ -250,7 +248,9 @@ if (!defined('ABSPATH')) {
                            id="jwt_email_type_plain_text"
                            value="0"
                         <?php
-                        echo $jwtSettings->getResetPasswordSettings()->getResetPasswordEmailType() === 0 ? 'checked="checked"' : ''; ?>
+                        echo $jwtSettings->getResetPasswordSettings()->getResetPasswordEmailType() === 0
+                            ? 'checked="checked"'
+                            : ''; ?>
                     />
                     <label for="jwt_email_type_plain_text">
                         <?php echo __('Plain text', 'simple-jwt-login'); ?>
@@ -262,7 +262,9 @@ if (!defined('ABSPATH')) {
                            id="jwt_email_type_html"
                            value="1"
                         <?php
-                        echo $jwtSettings->getResetPasswordSettings()->getResetPasswordEmailType() === 1 ? 'checked="checked"' : ''; ?>
+                        echo $jwtSettings->getResetPasswordSettings()->getResetPasswordEmailType() === 1
+                            ? 'checked="checked"'
+                            : ''; ?>
                     />
                     <label for="jwt_email_type_html">
                         HTML

--- a/simple-jwt-login/views/reset-password-view.php
+++ b/simple-jwt-login/views/reset-password-view.php
@@ -97,10 +97,10 @@ if (!defined('ABSPATH')) {
             ?>
         </p>
         <p class="text-muted">
-            <?php echo __('Parameters', 'simple-jwt-login');?>:
+            <?php echo __('Parameters', 'simple-jwt-login'); ?>:
             <Br/>
             <b>email</b><span class="required">*</span> :
-            <?php echo __('The email address that needs reset password', 'simple-jwt-login');?>
+            <?php echo __('The email address that needs reset password', 'simple-jwt-login'); ?>
             <Br/>
             <br/>
             <?php
@@ -145,19 +145,19 @@ if (!defined('ABSPATH')) {
         <ul>
             <li>
                 <input type="radio"
-                    value="<?php
-                    echo esc_attr(ResetPasswordSettings::FLOW_JUST_SAVE_IN_DB); ?>"
+                       value="<?php
+                       echo esc_attr(ResetPasswordSettings::FLOW_JUST_SAVE_IN_DB); ?>"
                     <?php
                     echo (
-                            $jwtSettings->getResetPasswordSettings()->getFlowType()
-                            === ResetPasswordSettings::FLOW_JUST_SAVE_IN_DB
+                        $jwtSettings->getResetPasswordSettings()->getFlowType()
+                        === ResetPasswordSettings::FLOW_JUST_SAVE_IN_DB
                     )
                         ? 'checked="checked"'
                         : '';
                     ?>
-                    name="jwt_reset_password_flow"
-                    class="jwt_reset_password_flow"
-                    id="jwt_reset_password_flow_db"
+                       name="jwt_reset_password_flow"
+                       class="jwt_reset_password_flow"
+                       id="jwt_reset_password_flow_db"
                 />
                 <label for="jwt_reset_password_flow_db">
                     <?php
@@ -170,18 +170,18 @@ if (!defined('ABSPATH')) {
             </li>
             <li>
                 <input type="radio"
-                    value="<?php
-                    echo esc_attr(ResetPasswordSettings::FLOW_SEND_DEFAULT_WP_EMAIL); ?>"
+                       value="<?php
+                       echo esc_attr(ResetPasswordSettings::FLOW_SEND_DEFAULT_WP_EMAIL); ?>"
                     <?php
-                        echo ($jwtSettings->getResetPasswordSettings()->getFlowType()
-                        === ResetPasswordSettings::FLOW_SEND_DEFAULT_WP_EMAIL
+                    echo($jwtSettings->getResetPasswordSettings()->getFlowType()
+                    === ResetPasswordSettings::FLOW_SEND_DEFAULT_WP_EMAIL
                         ? 'checked="checked"'
                         : ''
-                        );
-                        ?>
-                    name="jwt_reset_password_flow"
-                    class="jwt_reset_password_flow"
-                    id="jwt_reset_password_flow_wordpress"
+                    );
+                    ?>
+                       name="jwt_reset_password_flow"
+                       class="jwt_reset_password_flow"
+                       id="jwt_reset_password_flow_wordpress"
                 />
                 <label for="jwt_reset_password_flow_wordpress">
                     <?php
@@ -194,19 +194,19 @@ if (!defined('ABSPATH')) {
             </li>
             <li>
                 <input
-                        type="radio"
-                        value="<?php
-                           echo esc_attr(ResetPasswordSettings::FLOW_SEND_CUSTOM_EMAIL); ?>"
-                        <?php
-                        echo ($jwtSettings->getResetPasswordSettings()->getFlowType()
-                        === ResetPasswordSettings::FLOW_SEND_CUSTOM_EMAIL
-                            ? 'checked="checked"'
-                            : ''
-                        );
-                        ?>
-                        name="jwt_reset_password_flow"
-                        id="jwt_reset_password_flow_custom"
-                        class="jwt_reset_password_flow">
+                    type="radio"
+                    value="<?php
+                    echo esc_attr(ResetPasswordSettings::FLOW_SEND_CUSTOM_EMAIL); ?>"
+                    <?php
+                    echo($jwtSettings->getResetPasswordSettings()->getFlowType()
+                    === ResetPasswordSettings::FLOW_SEND_CUSTOM_EMAIL
+                        ? 'checked="checked"'
+                        : ''
+                    );
+                    ?>
+                    name="jwt_reset_password_flow"
+                    id="jwt_reset_password_flow_custom"
+                    class="jwt_reset_password_flow">
                 <label for="jwt_reset_password_flow_custom">
                     <?php
                     echo __(
@@ -223,14 +223,14 @@ if (!defined('ABSPATH')) {
     <div class="col-md-12">
         <div class="jwt_sub_container">
             <h4 class="sub-section-title">
-                <?php echo __('Email Subject', 'simple-jwt-login');?>
+                <?php echo __('Email Subject', 'simple-jwt-login'); ?>
             </h4>
             <input type="text"
                    name="jwt_email_subject"
                    class="form-control"
-                   placeholder="<?php echo __('Email Subject', 'simple-jwt-login');?>"
+                   placeholder="<?php echo __('Email Subject', 'simple-jwt-login'); ?>"
                    value="<?php
-                    echo esc_attr($jwtSettings->getResetPasswordSettings()->getResetPasswordEmailSubject()); ?>"
+                   echo esc_attr($jwtSettings->getResetPasswordSettings()->getResetPasswordEmailSubject()); ?>"
             />
             <br/>
             <h4 class="sub-section-title">Email body</h4>
@@ -239,8 +239,8 @@ if (!defined('ABSPATH')) {
                       id="reset_password_email_body"
                       placeholder="Email Content"
             ><?php
-                        echo esc_html($jwtSettings->getResetPasswordSettings()->getResetPasswordEmailBody());
-            ?></textarea>
+                echo esc_html($jwtSettings->getResetPasswordSettings()->getResetPasswordEmailBody());
+                ?></textarea>
             <br/>
             <h4 class="sub-section-title">Email type</h4>
             <ul>
@@ -250,11 +250,10 @@ if (!defined('ABSPATH')) {
                            id="jwt_email_type_plain_text"
                            value="0"
                         <?php
-                        echo $jwtSettings->getResetPasswordSettings()->getResetPasswordEmailType(
-                        ) === 0 ? 'checked="checked"' : ''; ?>
+                        echo $jwtSettings->getResetPasswordSettings()->getResetPasswordEmailType() === 0 ? 'checked="checked"' : ''; ?>
                     />
                     <label for="jwt_email_type_plain_text">
-                        <?php echo __('Plain text', 'simple-jwt-login');?>
+                        <?php echo __('Plain text', 'simple-jwt-login'); ?>
                     </label>
                 </li>
                 <li>
@@ -263,8 +262,7 @@ if (!defined('ABSPATH')) {
                            id="jwt_email_type_html"
                            value="1"
                         <?php
-                        echo $jwtSettings->getResetPasswordSettings()->getResetPasswordEmailType(
-                        ) === 1 ? 'checked="checked"' : ''; ?>
+                        echo $jwtSettings->getResetPasswordSettings()->getResetPasswordEmailType() === 1 ? 'checked="checked"' : ''; ?>
                     />
                     <label for="jwt_email_type_html">
                         HTML
@@ -280,7 +278,7 @@ if (!defined('ABSPATH')) {
             ?>
             <br/>
             <br/>
-            <b><?php echo __('Available variables', 'simple-jwt-login');?></b>:
+            <b><?php echo __('Available variables', 'simple-jwt-login'); ?></b>:
             <ul>
                 <?php
                 foreach ($jwtSettings->getResetPasswordSettings()->getEmailContentVariables() as $variable => $text) {
@@ -313,18 +311,18 @@ if (!defined('ABSPATH')) {
             ?>
         </p>
         <p class="text-muted">
-            <?php echo __('Parameters', 'simple-jwt-login');?>:
+            <?php echo __('Parameters', 'simple-jwt-login'); ?>:
             <br/>
             <b>email</b><span class="required">*</span> :
-            <?php echo __('The email address that needs reset password', 'simple-jwt-login');?>
+            <?php echo __('The email address that needs reset password', 'simple-jwt-login'); ?>
             <br/>
 
             <b>code</b><span class="required">*</span> :
-            <?php echo __('The code received on email', 'simple-jwt-login');?>
+            <?php echo __('The code received on email', 'simple-jwt-login'); ?>
             <br/>
 
             <b>new_password</b><span class="required">*</span> :
-            <?php echo __('New password for the user', 'simple-jwt-login');?>
+            <?php echo __('New password for the user', 'simple-jwt-login'); ?>
             <br/>
             <br/>
             <?php
@@ -334,35 +332,13 @@ if (!defined('ABSPATH')) {
             );
             ?>
         </p>
-        <div class="">
-            <h4 class="sub-section-title">
-                <?php echo __('Reset password with JWT', 'simple-jwt-login');?>
-            </h4>
-
-            <input type="checkbox" name="reset_password_jwt"
-                   id="reset_password_jwt"
-                <?php echo($jwtSettings->getResetPasswordSettings()->isJwtAllowed() ? 'checked' : ''); ?>
-                   value="1"/>
-            <label for="reset_password_jwt">
-                <?php echo __('Allow Reset password with JWT', 'simple-jwt-login'); ?>
-            </label>
-            <p class="text-muted">
-                <?php
-                echo __(
-                    'If this option is selected, the <b>code</b> parameter is no longer required.'
-                    . ' The plugin will search for the USER that is present in the JWT. Also, the JWT should be valid.',
-                    'simple-jwt-login'
-                );
-                ?>
-            </p>
-        </div>
         <div class="generated-code">
             <span class="method">PUT:</span>
             <span class="code">
                 <?php
                 $sampleUrlParams = [
-                    'email'        => __('Email', 'simple-jwt-login'),
-                    'code'         => __('Code', 'simple-jwt-login'),
+                    'email' => __('Email', 'simple-jwt-login'),
+                    'code' => __('Code', 'simple-jwt-login'),
                     'new_password' => __('New password', 'simple-jwt-login'),
                 ];
 
@@ -382,6 +358,31 @@ if (!defined('ABSPATH')) {
                 </button>
             </span>
         </div>
+    </div>
+</div>
+<br />
+<div class="row">
+    <div class="col-md-12">
+        <h4 class="sub-section-title">
+            <?php echo __('Reset password with JWT', 'simple-jwt-login'); ?>
+        </h4>
+
+        <input type="checkbox" name="reset_password_jwt"
+               id="reset_password_jwt"
+            <?php echo($jwtSettings->getResetPasswordSettings()->isJwtAllowed() ? 'checked' : ''); ?>
+               value="1"/>
+        <label for="reset_password_jwt">
+            <?php echo __('Allow Reset password with JWT', 'simple-jwt-login'); ?>
+        </label>
+        <p class="text-muted">
+            <?php
+            echo __(
+                'If this option is selected, the <b>code</b> parameter is no longer required.'
+                . ' The plugin will search for the USER that is present in the JWT. Also, the JWT should be valid.',
+                'simple-jwt-login'
+            );
+            ?>
+        </p>
     </div>
 </div>
 <hr/>

--- a/tests/Helpers/ArrayHelperTest.php
+++ b/tests/Helpers/ArrayHelperTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace SimpleJwtLoginTests\Helpers;
+
+use PHPUnit\Framework\TestCase;
+use SimpleJWTLogin\Helpers\ArrayHelper;
+
+class ArrayHelperTest extends TestCase
+{
+    /**
+     * @dataProvider convertStringToArrayProvider
+     * @param string $string
+     * @param string[] $expectedResult
+     * @return void
+     */
+    public function testConvertStringToArray($string, $expectedResult)
+    {
+        $result = ArrayHelper::convertStringToArray($string);
+
+        $this->assertEquals(
+            $expectedResult,
+            $result
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public static function convertStringToArrayProvider()
+    {
+        return [
+            'empty_string' => [
+                'string' => '',
+                'result' => [
+                    0 => '',
+                ],
+            ],
+            'string_without_spaces' => [
+                'string' => 'a,b,c',
+                'result' => [
+                    'a',
+                    'b',
+                    'c',
+                ],
+            ],
+            'strings_with_spaces' => [
+                'string' => 'a, b, c',
+                'result' => [
+                    'a',
+                    'b',
+                    'c',
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/Libraries/ParseRequestTest.php
+++ b/tests/Libraries/ParseRequestTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Libraries;
+namespace SimpleJwtLoginTests\Libraries;
 
 use PHPUnit\Framework\TestCase;
 use SimpleJWTLogin\Libraries\ParseRequest;

--- a/tests/Modules/Settings/AuthCodesSettingsTest.php
+++ b/tests/Modules/Settings/AuthCodesSettingsTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace SimpleJWTLoginTests\Modules\Settings;
+namespace SimpleJwtLoginTests\Modules\Settings;
 
 use Exception;
 use PHPUnit\Framework\TestCase;

--- a/tests/Modules/Settings/AuthenticationSettingsTest.php
+++ b/tests/Modules/Settings/AuthenticationSettingsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SimpleJWTLoginTests\Modules\Settings;
+namespace SimpleJwtLoginTests\Modules\Settings;
 
 use Exception;
 use PHPUnit\Framework\TestCase;

--- a/tests/Modules/Settings/CorsSettingsTest.php
+++ b/tests/Modules/Settings/CorsSettingsTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace SimpleJWTLoginTests\Modules\Settings;
+namespace SimpleJwtLoginTests\Modules\Settings;
 
 use Exception;
 use PHPUnit\Framework\TestCase;

--- a/tests/Modules/Settings/DeleteUserSettingsTest.php
+++ b/tests/Modules/Settings/DeleteUserSettingsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SimpleJWTLoginTests\Modules\Settings;
+namespace SimpleJwtLoginTests\Modules\Settings;
 
 use Exception;
 use PHPUnit\Framework\TestCase;

--- a/tests/Modules/Settings/GeneralSettingsTest.php
+++ b/tests/Modules/Settings/GeneralSettingsTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace SimpleJWTLoginTests\Modules\Settings;
+namespace SimpleJwtLoginTests\Modules\Settings;
 
 use Exception;
 use PHPUnit\Framework\TestCase;

--- a/tests/Modules/Settings/HooksSettingsTest.php
+++ b/tests/Modules/Settings/HooksSettingsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SimpleJWTLoginTests\Modules\Settings;
+namespace SimpleJwtLoginTests\Modules\Settings;
 
 use PHPUnit\Framework\TestCase;
 use SimpleJWTLogin\Modules\Settings\HooksSettings;

--- a/tests/Modules/Settings/LoginSettingsTest.php
+++ b/tests/Modules/Settings/LoginSettingsTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace SimpleJWTLoginTests\Modules\Settings;
+namespace SimpleJwtLoginTests\Modules\Settings;
 
 use Exception;
 use PHPUnit\Framework\TestCase;

--- a/tests/Modules/Settings/RegisterSettingsTest.php
+++ b/tests/Modules/Settings/RegisterSettingsTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace SimpleJWTLoginTests\Modules\Settings;
+namespace SimpleJwtLoginTests\Modules\Settings;
 
 use Exception;
 use PHPUnit\Framework\TestCase;

--- a/tests/Modules/Settings/ResetPasswordSettingsTest.php
+++ b/tests/Modules/Settings/ResetPasswordSettingsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SimpleJWTLoginTests\Modules\Settings;
+namespace SimpleJwtLoginTests\Modules\Settings;
 
 use Exception;
 use PHPUnit\Framework\TestCase;

--- a/tests/Modules/Settings/SettingsFactoryTest.php
+++ b/tests/Modules/Settings/SettingsFactoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SimpleJWTLoginTests\Modules\Settings;
+namespace SimpleJwtLoginTests\Modules\Settings;
 
 use Exception;
 use PHPUnit\Framework\TestCase;
@@ -25,9 +25,11 @@ class SettingsFactoryTest extends TestCase
      */
     public function testInstances($type, $expectedInstance)
     {
+        $factory = SettingsFactory::getFactory($type);
+
         $this->assertInstanceOf(
             $expectedInstance,
-            SettingsFactory::getFactory($type)
+            $factory
         );
     }
 

--- a/tests/Services/AuthenticateServiceTest.php
+++ b/tests/Services/AuthenticateServiceTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace SimpleJWTLoginTests\Services;
+namespace SimpleJwtLoginTests\Services;
 
 use Exception;
 use PHPUnit\Framework\TestCase;

--- a/tests/Services/DeleteUserServiceTest.php
+++ b/tests/Services/DeleteUserServiceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SimpleJWTLoginTests\Services;
+namespace SimpleJwtLoginTests\Services;
 
 use Exception;
 use PHPUnit\Framework\TestCase;

--- a/tests/Services/RegisterUserServiceTest.php
+++ b/tests/Services/RegisterUserServiceTest.php
@@ -300,7 +300,15 @@ class RegisterUserServiceTest extends TestCase
 
     public function testRegisterSuccessWithJwtFromAuth()
     {
+        $this->wordPressDataMock->method('isEmail')
+            ->willReturn(true);
+        $this->wordPressDataMock->method('checkUserExistsByUsernameAndEmail')
+            ->willReturn(false);
+        $this->wordPressDataMock->method('getSiteUrl')
+            ->willReturn("http://test.com");
+
         $authSettings = new AuthenticationSettings();
+        $authSettings->withWordPressData($this->wordPressDataMock);
         $this->wordPressDataMock->method('getOptionFromDatabase')
             ->willReturn(json_encode([
                 'allow_authentication' => true,
@@ -311,11 +319,6 @@ class RegisterUserServiceTest extends TestCase
                 'register_jwt' => true,
                 'jwt_payload' => $authSettings->getJwtPayloadParameters(),
             ]));
-
-        $this->wordPressDataMock->method('isEmail')
-            ->willReturn(true);
-        $this->wordPressDataMock->method('checkUserExistsByUsernameAndEmail')
-            ->willReturn(false);
 
 
         $this->wordPressDataMock->method('createUser')
@@ -372,8 +375,8 @@ class RegisterUserServiceTest extends TestCase
             ->willReturn(true);
         $this->wordPressDataMock->method('checkUserExistsByUsernameAndEmail')
             ->willReturn(false);
-
-
+        $this->wordPressDataMock->method('getSiteUrl')
+            ->willReturn("http://test.com");
         $this->wordPressDataMock->method('createUser')
             ->willReturn([]);
         $this->wordPressDataMock->method('getUserIdFromUser')

--- a/tests/Services/RouteServiceTest.php
+++ b/tests/Services/RouteServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 
-namespace SimpleJWTLoginTests\Services;
+namespace SimpleJwtLoginTests\Services;
 
 use Exception;
 use PHPUnit\Framework\TestCase;

--- a/tests/Services/ValidateTokenServiceTest.php
+++ b/tests/Services/ValidateTokenServiceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SimpleJWTLoginTests\Services;
+namespace SimpleJwtLoginTests\Services;
 
 use Exception;
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
## Issue Link
<!-- please add issue link -->

## Types of changes
- [ ] Bug fix
- [x] New feature

## Description
<!-- Please describe what you have changed or added -->
Add `iss` to the authentication payload, and allow users `iss` configuration on autologin.

If `iss` is empty in the autologin settings, this means that it will not be validated. 

## Checklist:
- [x] My code is tested.
- [x] I wrote tests for the impacted area
- [x] I ran `composer check-plugin` locally