### PR TITLE
Add username to email body

### DIFF
--- a/simple-jwt-login/src/Modules/Settings/ResetPasswordSettings.php
+++ b/simple-jwt-login/src/Modules/Settings/ResetPasswordSettings.php
@@ -157,6 +157,7 @@ class ResetPasswordSettings extends BaseSettings implements SettingsInterface
         return [
             '{{CODE}}' => __('Reset password code', 'simple-jwt_login'),
             '{{NAME}}' => __('User first and last name', 'simple-jwt-login'),
+            '{{USERNAME}}' => __('User name', 'simple-jwt_login'),
             '{{EMAIL}}' => __('User email', 'simple-jwt_login'),
             '{{NICKNAME}}' => __('User nickname', 'simple-jwt_login'),
             '{{FIRST_NAME}}' => __('User first name', 'simple-jwt_login'),

--- a/simple-jwt-login/src/Services/ResetPasswordService.php
+++ b/simple-jwt-login/src/Services/ResetPasswordService.php
@@ -209,6 +209,9 @@ class ResetPasswordService extends BaseService implements ServiceInterface
                     $replace = $this->wordPressData->getUserProperty($user, 'first_name')
                                . $this->wordPressData->getUserProperty($user, 'last_name');
                     break;
+                case "{{USERNAME}}":
+                    $replace = $this->wordPressData->getUserProperty($user, 'user_login');
+                    break;
                 case "{{EMAIL}}":
                     $replace = $this->wordPressData->getUserProperty($user, 'user_login');
                     break;

--- a/simple-jwt-login/src/Services/ResetPasswordService.php
+++ b/simple-jwt-login/src/Services/ResetPasswordService.php
@@ -213,7 +213,7 @@ class ResetPasswordService extends BaseService implements ServiceInterface
                     $replace = $this->wordPressData->getUserProperty($user, 'user_login');
                     break;
                 case "{{EMAIL}}":
-                    $replace = $this->wordPressData->getUserProperty($user, 'user_login');
+                    $replace = $this->wordPressData->getUserProperty($user, 'user_email');
                     break;
                 case "{{NICKNAME}}":
                     $replace = $this->wordPressData->getUserProperty($user, 'nickname');


### PR DESCRIPTION
## Types of changes
- [X] Bug fix
- [X] New feature

## Description
Fix the email variable in email body
Add user name to email body

## How has this been tested?
From the reset custom email message

## Checklist:
- [X] My code is tested.
- [X] I wrote tests for the impacted area
- [X] I ran `composer check-plugin` locally