### PR TITLE
Ensure password slashing before validation

### DIFF
--- a/phpstan_bootstrap.php
+++ b/phpstan_bootstrap.php
@@ -428,6 +428,12 @@ if (!function_exists('wp_remote_retrieve_body')) {
     function wp_remote_retrieve_body($response) {
     }
 }
+if (!function_exists('wp_slash')) {
+    function wp_slash($value)
+    {
+        return $value;
+    }
+}
 
 if (!class_exists('WP_REST_Response')) {
     class WP_REST_Response

--- a/simple-jwt-login/src/Modules/WordPressData.php
+++ b/simple-jwt-login/src/Modules/WordPressData.php
@@ -120,7 +120,7 @@ class WordPressData implements WordPressDataInterface
     public function createUser($username, $email, $password, $role, $extraParameters = [])
     {
         $userParameters = [
-            'user_pass'  => $password,
+            'user_pass'  => wp_slash($password),
             'user_login' => $username,
             'user_email' => $email,
         ];

--- a/simple-jwt-login/src/Services/AuthenticateService.php
+++ b/simple-jwt-login/src/Services/AuthenticateService.php
@@ -134,7 +134,7 @@ class AuthenticateService extends BaseService implements ServiceInterface
         }
 
         $dbPassword = $this->wordPressData->getUserPassword($user);
-        $passwordMatch = $this->wordPressData->checkPassword($password, $passwordHash, $dbPassword);
+        $passwordMatch = $this->wordPressData->checkPassword(wp_slash($password), $passwordHash, $dbPassword);
 
         if ($passwordMatch === false) {
             throw new Exception(

--- a/tests/Feature/Authentication/SuccessTest.php
+++ b/tests/Feature/Authentication/SuccessTest.php
@@ -67,6 +67,33 @@ class SuccessTest extends TestBase
         $this->assertSame(200, $statusCode, "unable to delete the user");
     }
 
+    #[TestDox("User can authenticate with email and password that contains special characters")]
+    public function testAuthenticationEmailWithSpecialCharacterPassword()
+    {
+        // Register random user
+        list ($email, $password, $statusCode, $response) = $this->registerRandomUser("I!Wqn^&oZg*kscZVrzH^41yvaRj'");
+
+        $this->assertSame(200, $statusCode, "Unable to register user");
+
+        // Auth new USer
+        list ($statusCode, $responseContents) = $this->authUser($email, $password);
+
+        $this->assertSame(
+            200,
+            $statusCode,
+            "Auth User Failed"
+        );
+        $responseArray = json_decode($responseContents, true);
+        $this->assertArrayHasKey('success', $responseArray);
+        $this->assertTrue($responseArray['success']);
+        $this->assertArrayHasKey('data', $responseArray);
+        $this->assertArrayHasKey('jwt', $responseArray['data']);
+        $jwt = $responseArray['data']['jwt'];
+        // Cleanup
+        list($statusCode, $response) = $this->deleteUser($jwt);
+        $this->assertSame(200, $statusCode, "unable to delete the user");
+    }
+
 
     #[TestDox("User can refresh a valid JWT")]
     public function testRefreshToken()

--- a/tests/Feature/RegisterUsers/SuccessTest.php
+++ b/tests/Feature/RegisterUsers/SuccessTest.php
@@ -94,6 +94,30 @@ class SuccessTest extends TestBase
         $this->assertSame(true, $json['success']);
     }
 
+    #[TestDox("User can register with JSON body and a password that includes special characters")]
+    public function testSuccessWithJSONBodyAndSpecialCharacterPassword()
+    {
+        $faker = Factory::create();
+        $uri = self::API_URL . "?rest_route=/simple-jwt-login/v1/users";
+        $result = $this->client->post($uri, [
+            'body' => json_encode([
+                "email"  => $faker->numberBetween(0, 1000) . $faker->email(),
+                "password" => "I!Wqn^&oZg*kscZVrzH^41yvaRj'",
+            ]),
+        ]);
+
+        $this->assertSame(
+            200,
+            $result->getStatusCode()
+        );
+
+        $contents = $result->getBody()->getContents();
+        $this->assertJson($contents);
+        $json = json_decode($contents, true);
+        $this->assertArrayHasKey('success', $json);
+        $this->assertSame(true, $json['success']);
+    }
+
     #[TestDox("User can register with custom user_meta")]
     /**
      * @return void

--- a/tests/Feature/TestBase.php
+++ b/tests/Feature/TestBase.php
@@ -204,11 +204,14 @@ class TestBase extends TestCase
     /**
      * @return array<int,string>
      */
-    protected function registerRandomUser()
+    protected function registerRandomUser(string $overridePassword = null)
     {
         $faker = Factory::create();
         $email = $faker->randomNumber(6) . $faker->email();
         $password = "1234";
+        if ($overridePassword !== null) {
+            $password = $overridePassword;
+        }
 
         $uri = self::API_URL . "?rest_route=/simple-jwt-login/v1/users";
         $result = $this->client->post($uri, [


### PR DESCRIPTION
Updated the password-checking mechanism to include `wp_slash` for the input password to improve security. Additionally, added a mock implementation of `wp_slash` in `phpstan_bootstrap.php` for testing purposes.


## Issue Link
https://github.com/nicumicle/simple-jwt-login/issues/116

## Types of changes
- [x] Bug fix
- [ ] New feature

## Description
Added the function wp_slash to further protect passwords coming from json
https://developer.wordpress.org/reference/functions/wp_slash/

## How has this been tested?
added nullable parameter to the TestBase->registerRandomUser to pass a password. If the parameter is not null it overrides the $password field. This prevents code duplication.

Added Two new Test Cases.

### Authentication/Success
- Added testAuthenticationEmailWithSpecialCharacterPassword to use a password with special characters.

### RegisterUsers
- Added testSuccessWithJSONBodyAndSpecialCharacterPassword to use a password with special characters.


## Screenshots (optional)
![image](https://github.com/user-attachments/assets/bdcaaf9f-df4e-46c7-a10b-fb3b974346e8)

![image](https://github.com/user-attachments/assets/9d608dab-9eb8-4e0d-be0e-2cd796411adb)

![image](https://github.com/user-attachments/assets/55764dc9-aa6c-48f3-82c5-d241aaf00e98)

## Checklist:
- [x] My code is tested.
- [x] I wrote tests for the impacted area
- [x] I ran `composer check-plugin` locally