### PR TITLE
#115: Add option for wp_safe_redirect

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 # Changelog - Releases
 
 ## Unreleased
+- use wp_safe_redirect for redirects [#115](https://github.com/nicumicle/simple-jwt-login/issues/115)
 
 ## 3.5.7 (22 Dec 2024)
 - Update WordPress 6.7 Compatibility

--- a/README.md
+++ b/README.md
@@ -97,14 +97,14 @@ If you want to upload the simple-jwt-login plugin to your website:
 ### Install from WordPress.org
 
 > [!TIP]
->  For production environments we recommend installing the plugin from Wordpress.org 
+>  For production environments we recommend installing the plugin from WordPress.org 
 
 In order to install the latest stable version, from your WordPress admin:
 - Go to the ‘Plugins’ menu in WordPress and click ‘Add New’
 - Search for ‘Simple JWT Login’ and select ‘Install Now’
 - Activate the plugin when prompted
 
-### Setup the Plugin
+### Set up the Plugin
 
 1. Go to "General" section
 2. Set a "JWT Decryption key". With this key the JWT will be validated.
@@ -123,7 +123,7 @@ In order to install the latest stable version, from your WordPress admin:
 - **Delete user**: You can delete a WordPress user by adding some details in the JWT payload.
 - **Reset password**: REST endpoint that allows you to reset WordPress User password. Also, it can send custom email if you want.
 - **Protect endpoints**: Protect WordPress endpoints with a JWT. This way, you can make some endpoints private, and the content can be viewed only if you provide a valid JWT.
-- **Allow JWT usage on other endpoints**: Add a JWT to requests for other API endpoints and you will act as an authenticated user.
+- **Allow JWT usage on other endpoints**: Add a JWT to requests for other API endpoints, and you will act as an authenticated user.
 - **Integrate with other plugins**: This plugin works well in combination with other plugins that extends the WordPress REST API.
 - **Google OAuth**(beta):  Login to your website with Google
 - **Google JWT**(beta): Use the Google `id_token` in order to access WordPress endpoints as an authenticated user.

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
   "name": "nicumicle/simple-jwt-login",
   "description": "Simple JWT Login WordPress plugin",
-  "version": "1.0.0",
   "require": {
     "php": ">=7.0",
     "ext-json": "*",

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "guzzlehttp/guzzle": "^7.8"
   },
   "license": [
-    "GPL-3.0-or-later"
+    "GPL-3.0-only"
   ],
   "require-dev": {
     "friendsofphp/php-cs-fixer": "*",

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
   "name": "nicumicle/simple-jwt-login",
   "description": "Simple JWT Login WordPress plugin",
+  "version": "1.0.0",
   "require": {
     "php": ">=7.0",
     "ext-json": "*",
@@ -8,7 +9,8 @@
     "guzzlehttp/guzzle": "^7.8"
   },
   "license": [
-    "GPL-3.0-only"
+    "GPL-3.0-only",
+    "BSD-3-Clause"
   ],
   "require-dev": {
     "friendsofphp/php-cs-fixer": "*",

--- a/phpstan_bootstrap.php
+++ b/phpstan_bootstrap.php
@@ -70,6 +70,13 @@ if (!function_exists('wp_redirect')) {
     {
     }
 }
+
+if (!function_exists('wp_safe_redirect')) {
+    function wp_safe_redirect($url)
+    {
+    }
+}
+
 if (!function_exists('admin_url')) {
     function admin_url()
     {

--- a/simple-jwt-login/src/Modules/Settings/GeneralSettings.php
+++ b/simple-jwt-login/src/Modules/Settings/GeneralSettings.php
@@ -132,6 +132,14 @@ class GeneralSettings extends BaseSettings implements SettingsInterface
             'header',
             BaseSettings::SETTINGS_TYPE_STRING
         );
+
+        $this->assignSettingsPropertyFromPost(
+            'security',
+            'safe_redirect',
+            'security',
+            'safe_redirect',
+            BaseSettings::SETTINGS_TYPE_BOL
+        );
     }
 
     /**
@@ -394,5 +402,12 @@ class GeneralSettings extends BaseSettings implements SettingsInterface
         return isset($this->settings['api_middleware'])
             && isset($this->settings['api_middleware']['enabled'])
             && !empty($this->settings['api_middleware']['enabled']);
+    }
+
+    public function isSafeRedirectEnabled()
+    {
+        return isset($this->settings['security'])
+            && isset($this->settings['security']['safe_redirect'])
+            && !empty($this->settings['security']['safe_redirect']);
     }
 }

--- a/simple-jwt-login/src/Modules/WordPressData.php
+++ b/simple-jwt-login/src/Modules/WordPressData.php
@@ -63,6 +63,16 @@ class WordPressData implements WordPressDataInterface
     }
 
     /**
+     * @SuppressWarnings(ExitExpression)
+     * @param string $url
+     */
+    public function redirectSafe($url)
+    {
+        wp_safe_redirect($url);
+        exit;
+    }
+
+    /**
      * @return string
      */
     public function getAdminUrl()

--- a/simple-jwt-login/src/Modules/WordPressDataInterface.php
+++ b/simple-jwt-login/src/Modules/WordPressDataInterface.php
@@ -38,6 +38,11 @@ interface WordPressDataInterface
     public function redirect($url);
 
     /**
+     * @param string $url
+     */
+    public function redirectSafe($url);
+
+    /**
      * @return string
      */
     public function getAdminUrl();

--- a/simple-jwt-login/src/Services/Applications/Google.php
+++ b/simple-jwt-login/src/Services/Applications/Google.php
@@ -174,7 +174,7 @@ class Google extends BaseApplication implements ApplicationInterface
             $jsonResult = $result['response'];
 
             if ($responseStatusCode !== 200) {
-                $this->wordPressData->redirect($this->wordPressData->getLoginURL([
+                $this->redirect($this->wordPressData->getLoginURL([
                     'error' => $this->handleErrorMessage($jsonResult)
                 ]));
 
@@ -190,23 +190,34 @@ class Google extends BaseApplication implements ApplicationInterface
                     $user = $this->createUser($email);
 
                     $this->wordPressData->loginUser($user);
-                    $this->wordPressData->redirect($this->wordPressData->getAdminUrl());
+                    $this->redirect($this->wordPressData->getAdminUrl());
 
                     return;
                 }
 
-                $this->wordPressData->redirect($this->wordPressData->getLoginURL([]));
+                $this->redirect($this->wordPressData->getLoginURL([]));
 
                 return;
             }
 
             $this->wordPressData->loginUser($user);
-            $this->wordPressData->redirect($this->wordPressData->getAdminUrl());
+            $this->redirect($this->wordPressData->getAdminUrl());
 
             return;
         } catch (Exception $e) {
-            $this->wordPressData->redirect($this->wordPressData->getLoginURL(['error' => $e->getMessage()]));
+            $this->redirect($this->wordPressData->getLoginURL(['error' => $e->getMessage()]));
         }
+    }
+
+    private function redirect($url)
+    {
+        if ($this->settings->getGeneralSettings()->isSafeRedirectEnabled()) {
+            $this->wordPressData->redirectSafe($url);
+
+            return;
+        }
+
+        $this->wordPressData->redirect($url);
     }
 
     /**

--- a/simple-jwt-login/src/Services/LoginService.php
+++ b/simple-jwt-login/src/Services/LoginService.php
@@ -28,6 +28,10 @@ class LoginService extends BaseService implements ServiceInterface
                         'error_code' => $e->getCode()
                     ]);
 
+                if ($this->jwtSettings->getGeneralSettings()->isSafeRedirectEnabled()) {
+                    return $this->wordPressData->redirectSafe($redirectOnFail);
+                }
+
                 return $this->wordPressData->redirect($redirectOnFail);
             }
             throw new Exception($e->getMessage(), $e->getCode(), $e);

--- a/simple-jwt-login/src/Services/RedirectService.php
+++ b/simple-jwt-login/src/Services/RedirectService.php
@@ -96,6 +96,11 @@ class RedirectService extends BaseService implements ServiceInterface
             return $this->wordPressData->createResponse($response);
         }
 
+        if ($this->jwtSettings->getGeneralSettings()->isSafeRedirectEnabled()) {
+             $this->wordPressData->redirectSafe($url);
+
+             return null;
+        }
         $this->wordPressData->redirect($url);
 
         return null;

--- a/simple-jwt-login/views/general-view.php
+++ b/simple-jwt-login/views/general-view.php
@@ -328,11 +328,8 @@ if (!defined('ABSPATH')) {
         </select>
     </div>
     <div class="col-md-5">
-        <div class="code">$_SESSION['<b>
-                <?php
-                echo esc_html($jwtSettings->getGeneralSettings()->getRequestKeySession());
-                ?>
-            </b>']
+        <div class="code">
+            $_SESSION['<b><?php echo esc_html($jwtSettings->getGeneralSettings()->getRequestKeySession()); ?></b>']
         </div>
     </div>
 </div>
@@ -372,11 +369,8 @@ if (!defined('ABSPATH')) {
         </select>
     </div>
     <div class="col-md-5">
-        <div class="code">$_COOKIE['<b>
-                <?php
-                echo esc_html($jwtSettings->getGeneralSettings()->getRequestKeyCookie());
-                ?>
-            </b>']
+        <div class="code">
+            $_COOKIE['<b><?php echo esc_html($jwtSettings->getGeneralSettings()->getRequestKeyCookie()); ?></b>']
         </div>
     </div>
 </div>
@@ -476,7 +470,7 @@ if (!defined('ABSPATH')) {
             ?>
         />
         <label for="security_safe_redirect">
-            <?php echo __('Enable Safe redirects', 'simple-jwt-login');?>
+            <?php echo __('Enable safe redirects', 'simple-jwt-login');?>
         </label><br/>
         <p class="text-muted">
             * <?php

--- a/simple-jwt-login/views/general-view.php
+++ b/simple-jwt-login/views/general-view.php
@@ -458,3 +458,34 @@ if (!defined('ABSPATH')) {
         </p>
     </div>
 </div>
+
+
+<div class="row">
+    <div class="col-md-12">
+        <h3 class="section-title">
+          <?php echo __('Security', 'simple-jwt-login');?>
+        </h3>
+    </div>
+    <div class="col-md-12">
+        <input type="checkbox" name="security[safe_redirect]" id="security_safe_redirect"
+               value="1"
+            <?php
+            echo $jwtSettings->getGeneralSettings()->isSafeRedirectEnabled()
+                ? 'checked="checked"'
+                : ""
+            ?>
+        />
+        <label for="security_safe_redirect">
+            <?php echo __('Enable Safe redirects', 'simple-jwt-login');?>
+        </label><br/>
+        <p class="text-muted">
+            * <?php
+            echo __(
+                'Use wp_safe_redirect for all the redirects',
+                'simple-jwt-login'
+            );
+            ?>
+        </p>
+    </div>
+</div>
+

--- a/tests/Feature/Autologin/SuccessTest.php
+++ b/tests/Feature/Autologin/SuccessTest.php
@@ -36,6 +36,9 @@ class SuccessTest extends TestBase
             "jwt_login_by" => 0,
             "jwt_login_by_parameter" => "email",
             "allow_autologin" => true,
+            "security" => [
+                "safe_redirect" => true,
+            ]
         ]);
     }
 


### PR DESCRIPTION
## Issue Link
<!-- please add issue link -->

## Types of changes
- [ ] Bug fix
- [x] New feature

## Description
Add an option for allowing the usage of `wp_safe_redirect` instead of `wp_redirect`.

## How has this been tested?

## Screenshots (optional)
![image](https://github.com/user-attachments/assets/dbb11052-2017-42b7-af4b-ed0f63a9c81f)


## Checklist:
- [x] My code is tested.
- [ ] I wrote tests for the impacted area
- [x] I ran `composer check-plugin` locally