### PR TITLE
Ensure Jwt middleware is only run once

### DIFF
--- a/phpstan_bootstrap.php
+++ b/phpstan_bootstrap.php
@@ -479,6 +479,7 @@ if (!class_exists('WP_User')) {
 if (!class_exists('WP_Error')) {
     class WP_Error
     {
+	    public function __construct( $code = '', $message = '', $data = '' ) {}
 
     }
 }

--- a/simple-jwt-login/routes/api.php
+++ b/simple-jwt-login/routes/api.php
@@ -66,6 +66,10 @@ add_action('rest_api_init', function () {
 
     if ($jwtSettings->getGeneralSettings()->isMiddlewareEnabled()) {
         add_filter('rest_authentication_errors', function ($errors) use ($routeService, $jwtSettings) {
+	        if (!empty($errors)) {
+		        return $errors;
+	        }
+
             $currentURL =
                 "http"
                 . (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? "s" : "")
@@ -95,7 +99,12 @@ add_action('rest_api_init', function () {
                         ],
                         StatusCodeHelper::getStatusCodeFromExeption($exception, 400)
                     );
-                    return new WP_Error($exception->getCode(), $exception->getMessage());
+
+	                /* The wp_send_json_error call breaks the filter chain; the return statement will never be reached.
+	                   however if we remove above lines, this will cause a change in the api error response format */
+
+	                $status = StatusCodeHelper::getStatusCodeFromExeption($exception, 400);
+	                return new WP_Error($exception->getCode(), $exception->getMessage(), ["status" => $status]);
                 }
             }
 


### PR DESCRIPTION
## Issue Link
https://github.com/nicumicle/simple-jwt-login/issues/125

## Types of changes
- [x] Bug fix
- [ ] New feature

## Description
Instead of using the _"rest_endpoints"_ Wordpress hook for authorization middleware use the "rest_authentication_errors" filters hook which only runs once per request. 

## How has this been tested?
- Tracing of the rest-api request code execution path.
- Analysis of HTTP Response headers, of version 3.5.7 and development version
- Run tests according to the contribution guide

## Checklist:
- [x] My code is tested.
- [ ] I wrote tests for the impacted area
- [x] I ran `composer check-plugin` locally