### PR TITLE
Update authorization header matching and allow backwards compatibility.

### DIFF
--- a/simple-jwt-login/src/Services/BaseService.php
+++ b/simple-jwt-login/src/Services/BaseService.php
@@ -179,18 +179,18 @@ abstract class BaseService
         if ($this->jwtSettings->getGeneralSettings()->isJwtFromHeaderEnabled()) {
             $headers = array_change_key_case($this->serverHelper->getHeaders(), CASE_LOWER);
             $headerKey = strtolower($this->jwtSettings->getGeneralSettings()->getRequestKeyHeader());
-            if (isset($headers[$headerKey])) {
-                $matches = [];
-                preg_match(
-                    '/^(?:Bearer)?[\s]*(.*)$/mi',
-                    $headers[$headerKey],
-                    $matches
-                );
+	        if (isset($headers[$headerKey])) {
+		        $matches = [];
+		        $match = preg_match(
+			        '/^(?:(\w+)\s+)?([\w\-.]+)$/mi',
+			        $headers[$headerKey],
+			        $matches
+		        );
 
-                if (isset($matches[1]) && !empty(trim($matches[1]))) {
-                    return $matches[1];
-                }
-            }
+		        if ($match && (empty($matches[1]) || strtolower($matches[1]) == "bearer")) {
+			        return $matches[2];
+		        }
+	        }
         }
         if ($this->jwtSettings->getGeneralSettings()->isJwtFromCookieEnabled()) {
             if (isset($this->cookie[$this->jwtSettings->getGeneralSettings()->getRequestKeyCookie()])) {


### PR DESCRIPTION
## Issue Link
[#132 ](https://github.com/nicumicle/simple-jwt-login/issues/132)

## Types of changes
- [x] Bug fix
- [ ] New feature

## Description

- Updated the Authorization header regular expression 
- Only process tokens sent with an empty scheme and Bearer schemes

## How has this been tested?
- Run tests according to the contribution guide
- Changes are covered by existing unit and integration tests 
- Acceptance test: Assigned application passwords to users and tested the /wp/v2/users/me endpoint.

No changes to existing simple-jwt-plugin behaviour.

## Checklist:
- [x] My code is tested.
- [ ] I wrote tests for the impacted area
- [x] I ran `composer check-plugin` locally