### PR TITLE
fix for bug: Reset password function doesn't use base64 encoding logi…

### DIFF
--- a/simple-jwt-login/src/Services/ResetPasswordService.php
+++ b/simple-jwt-login/src/Services/ResetPasswordService.php
@@ -52,6 +52,9 @@ class ResetPasswordService extends BaseService implements ServiceInterface
     {
         $this->validateChangePassword();
         $newPassword = $this->wordPressData->sanitizeTextField($this->request['new_password']);
+        if ($this->jwtSettings->getAuthenticationSettings()->isAuthPasswordBase64Encoded()) {
+            $newPassword = base64_decode($newPassword);
+        }
         $jwtAllowed = $this->jwtSettings->getResetPasswordSettings()->isJwtAllowed();
         if ($jwtAllowed === false && empty($this->request['code'])) {
             throw new Exception(


### PR DESCRIPTION
…c and doesn't allow user to use any special character #161


## Issue Link
https://github.com/nicumicle/simple-jwt-login/issues/161

## Types of changes
- [x] Bug fix
- [ ] New feature

## Description
Fixed "Reset password" functionality for case when "Authentication" is using base64 encoding.

## How has this been tested?
Tested manually with Postman for different behaviour when user type very different custom characters like (~`!@#$%^&*-_+=?/><.,'":;)

## Screenshots (optional)
<!-- Please provide some screenshots of your tests -->

## Checklist:
- [x] My code is tested.
- [ ] I wrote tests for the impacted area
- [x] I ran `composer check-plugin` locally