### PR TITLE
Fix potential undefined index warning in ProtectEndpointService

### DIFF
--- a/simple-jwt-login/src/Services/ProtectEndpointService.php
+++ b/simple-jwt-login/src/Services/ProtectEndpointService.php
@@ -46,8 +46,9 @@ class ProtectEndpointService extends BaseService
 
         $parsed = parse_url($currentUrl);
 
-        $path  = rtrim(str_replace($documentRoot, '', ABSPATH), '/');
-        $path = str_replace($path . '/wp-json', '', $parsed['path']);
+        //Initialize $path safely, checking if 'path' is available in $parsed
+		$basePath  = rtrim(str_replace($documentRoot, '', ABSPATH), '/');
+		$path = isset($parsed['path']) ? str_replace($basePath . '/wp-json', '', $parsed['path']) : '';
 
         $isEndpointsProtected = true;
         if (!empty(trim($path, '/'))) {


### PR DESCRIPTION
parse_url() does not always return a path key — for example when the URL has no path component. Directly accessing $parsed['path'] in that case triggers an Undefined index PHP warning.

## Types of changes
- [x] Bug fix
- [ ] New feature

## Description
Add isset() check before accessing $parsed['path'] to safely handle cases where parse_url() does not return a 'path' key. Rename intermediate variable to $basePath to avoid variable reuse confusion.

## How has this been tested?
I've been running this fix on my end for over a year, for more complex installations the debug log is flooded with warnings because of this.
